### PR TITLE
Fix tests by simplifying CSV load

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -46,9 +46,11 @@ def get_gsheet_client():
 def load_symbol_master():
     global _symbol_cache
     try:
-        context = ssl.create_default_context(cafile=certifi.where())
-        with urllib.request.urlopen(symbol_master_url, context=context) as response:
-            _symbol_cache = pd.read_csv(response, header=None, names=symbol_master_columns)
+        _symbol_cache = pd.read_csv(
+            symbol_master_url,
+            header=None,
+            names=symbol_master_columns,
+        )
         logger.debug("Loaded symbol master into memory")
     except Exception as e:
         logger.error(f"Failed to load symbol master: {str(e)}")


### PR DESCRIPTION
## Summary
- update CSV download logic to call `pd.read_csv` directly

## Testing
- `pytest tests/test_utils.py -q`
- `timeout 300 pytest -q` *(fails: KeyboardInterrupt after 44 tests)*

------
https://chatgpt.com/codex/tasks/task_e_685128c415008328a21f881f285d0b6a