### PR TITLE
Fix token manager import side effects

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,27 +1,35 @@
 # ------------------ app/auth.py ------------------
-import logging , os
-from app.token_manager import get_token_manager, AuthCodeMissingError, RefreshTokenError
+import logging, os
+from app.token_manager import (
+    get_token_manager,
+    AuthCodeMissingError,
+    RefreshTokenError,
+)
 
 logger = logging.getLogger(__name__)
-_token_manager = get_token_manager()
+
+
+def _token_manager():
+    """Helper to lazily obtain the TokenManager instance."""
+    return get_token_manager()
 
 def get_fyers():
     try:
-        return _token_manager.get_fyers_client()
+        return get_token_manager().get_fyers_client()
     except Exception as e:
         logger.exception("[AUTH] Failed to get Fyers client: %s", e)
         raise
 
 def get_auth_code_url():
     try:
-        return _token_manager.get_auth_code_url()
+        return get_token_manager().get_auth_code_url()
     except Exception as e:
         logger.exception("[AUTH] Failed to get auth code URL: %s", e)
         raise
 
 def get_access_token():
     try:
-        token = _token_manager.get_access_token()
+        token = get_token_manager().get_access_token()
         if token:
             return token
         logger.error("[AUTH] Access token is None")
@@ -32,7 +40,7 @@ def get_access_token():
 
 def refresh_access_token():
     try:
-        return _token_manager.refresh_token()
+        return get_token_manager().refresh_token()
     except RefreshTokenError as e:
         logger.error(f"[AUTH] Token refresh failed: {e}")
         raise  # Propagate so caller knows it's critical
@@ -42,10 +50,11 @@ def refresh_access_token():
 
 def generate_access_token():
     try:
-        token = _token_manager.generate_token()
+        token = get_token_manager().generate_token()
         if token:
             return token
         else:
             logger.error("[AUTH] Token generation returned None")
     except Exception as e:
         logger.exception("[AUTH] Error generating token: %s", e)
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,40 +6,67 @@ from app.token_manager import AuthCodeMissingError, RefreshTokenError
 
 class TestAuth(unittest.TestCase):
 
-    @patch("app.auth._token_manager.get_access_token", return_value="abc123")
-    def test_get_access_token_success(self, mock_get):
+    @patch("app.auth.get_token_manager")
+    def test_get_access_token_success(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.get_access_token.return_value = "abc123"
+        mock_get_mgr.return_value = manager
+
         token = auth.get_access_token()
         self.assertEqual(token, "abc123")
 
-    @patch("app.auth._token_manager.get_access_token", return_value=None)
-    def test_get_access_token_failure(self, mock_get):
+    @patch("app.auth.get_token_manager")
+    def test_get_access_token_failure(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.get_access_token.return_value = None
+        mock_get_mgr.return_value = manager
+
         with self.assertRaises(AuthCodeMissingError):
             auth.get_access_token()
 
-    @patch("app.auth._token_manager.refresh_token", return_value="refreshed123")
-    def test_refresh_access_token_success(self, mock_refresh):
+    @patch("app.auth.get_token_manager")
+    def test_refresh_access_token_success(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.refresh_token.return_value = "refreshed123"
+        mock_get_mgr.return_value = manager
+
         token = auth.refresh_access_token()
         self.assertEqual(token, "refreshed123")
 
-    @patch("app.auth._token_manager.refresh_token", side_effect=RefreshTokenError("Simulated failure"))
-    def test_refresh_access_token_failure(self, mock_refresh):
+    @patch("app.auth.get_token_manager")
+    def test_refresh_access_token_failure(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.refresh_token.side_effect = RefreshTokenError("Simulated failure")
+        mock_get_mgr.return_value = manager
+
         with self.assertRaises(RefreshTokenError):
             auth.refresh_access_token()
 
-    @patch("app.auth._token_manager.get_auth_code_url", return_value="https://fyers-auth.url")
-    def test_get_auth_code_url(self, mock_url):
+    @patch("app.auth.get_token_manager")
+    def test_get_auth_code_url(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.get_auth_code_url.return_value = "https://fyers-auth.url"
+        mock_get_mgr.return_value = manager
+
         url = auth.get_auth_code_url()
         self.assertIn("https://", url)
 
-    @patch("app.auth._token_manager.get_fyers_client")
-    def test_get_fyers_success(self, mock_fyers):
+    @patch("app.auth.get_token_manager")
+    def test_get_fyers_success(self, mock_get_mgr):
         client = MagicMock()
-        mock_fyers.return_value = client
+        manager = MagicMock()
+        manager.get_fyers_client.return_value = client
+        mock_get_mgr.return_value = manager
+
         result = auth.get_fyers()
         self.assertEqual(result, client)
 
-    @patch("app.auth._token_manager.get_fyers_client", side_effect=Exception("fail"))
-    def test_get_fyers_failure(self, mock_fyers):
+    @patch("app.auth.get_token_manager")
+    def test_get_fyers_failure(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.get_fyers_client.side_effect = Exception("fail")
+        mock_get_mgr.return_value = manager
+
         with self.assertRaises(Exception):
             auth.get_fyers()
 


### PR DESCRIPTION
## Summary
- delay token manager creation until runtime
- adjust auth helpers to fetch token manager each call
- update authentication tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d51d4cf883289aef97dd1cb1cdd9