### PR TITLE
Fix tests by setting env vars before imports

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,19 @@
 # ------------------ tests/test_auth.py ------------------
+import os
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
+
+# Ensure the application package is importable and required env vars are set
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("FYERS_APP_ID", "dummy")
+os.environ.setdefault("FYERS_SECRET_ID", "dummy")
+os.environ.setdefault("FYERS_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("WEBHOOK_SECRET_TOKEN", "dummy")
+os.environ.setdefault("GOOGLE_SHEET_ID", "dummy")
+os.environ.setdefault("FYERS_PIN", "0000")
+os.environ.setdefault("FYERS_AUTH_CODE", "dummy")
+
 from app import auth
 from app.token_manager import AuthCodeMissingError, RefreshTokenError
 

--- a/tests/test_fyers_api.py
+++ b/tests/test_fyers_api.py
@@ -1,7 +1,20 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
 import pandas as pd
 import logging
+
+# Make sure we can import the app package and provide required env variables
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("FYERS_APP_ID", "dummy")
+os.environ.setdefault("FYERS_SECRET_ID", "dummy")
+os.environ.setdefault("FYERS_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("WEBHOOK_SECRET_TOKEN", "dummy")
+os.environ.setdefault("GOOGLE_SHEET_ID", "dummy")
+os.environ.setdefault("FYERS_PIN", "0000")
+os.environ.setdefault("FYERS_AUTH_CODE", "dummy")
+
 from app.fyers_api import (
     _validate_order_params,
     _get_default_qty,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,19 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch, MagicMock
 from flask import Flask, json
+
+# Provide environment variables and import the blueprint
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("FYERS_APP_ID", "dummy")
+os.environ.setdefault("FYERS_SECRET_ID", "dummy")
+os.environ.setdefault("FYERS_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("WEBHOOK_SECRET_TOKEN", "dummy")
+os.environ.setdefault("GOOGLE_SHEET_ID", "dummy")
+os.environ.setdefault("FYERS_PIN", "0000")
+os.environ.setdefault("FYERS_AUTH_CODE", "dummy")
+
 from app.routes import webhook_bp
 
 class TestRoutes(unittest.TestCase):

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -1,10 +1,22 @@
+import os
+import sys
 import unittest
 from unittest.mock import patch, mock_open, MagicMock
 import json
-import os
 import threading
 import hashlib
 import requests
+
+# Ensure package import and provide env vars for load_env_variables
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("FYERS_APP_ID", "dummy")
+os.environ.setdefault("FYERS_SECRET_ID", "dummy")
+os.environ.setdefault("FYERS_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("WEBHOOK_SECRET_TOKEN", "dummy")
+os.environ.setdefault("GOOGLE_SHEET_ID", "dummy")
+os.environ.setdefault("FYERS_PIN", "0000")
+os.environ.setdefault("FYERS_AUTH_CODE", "dummy")
+
 from app.token_manager import (
     TokenManager, get_token_manager,
     TokenManagerException, AuthCodeMissingError, RefreshTokenError, EnvironmentVariableError

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,21 @@
+import os
+import sys
 import pytest
 from unittest.mock import patch, MagicMock, mock_open
 import pandas as pd
 from datetime import datetime, timedelta
-import os
-import sys
 import logging
 import gspread
+
+# Ensure app package importability and set required environment variables
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("FYERS_APP_ID", "dummy")
+os.environ.setdefault("FYERS_SECRET_ID", "dummy")
+os.environ.setdefault("FYERS_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("WEBHOOK_SECRET_TOKEN", "dummy")
+os.environ.setdefault("GOOGLE_SHEET_ID", "dummy")
+os.environ.setdefault("FYERS_PIN", "0000")
+os.environ.setdefault("FYERS_AUTH_CODE", "dummy")
 
 # Add the parent directory to the path so we can import utils
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
## Summary
- ensure unit tests configure environment variables before importing app modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853dc7543988328b32a73a0a769f71c