### PR TITLE
Remove Redis client usage

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,7 @@
 # ------------------ app/routes.py ------------------
 from flask import Blueprint, request, jsonify
 from app.fyers_api import get_ltp, place_order, _validate_order_params
-from app.utils import log_trade_to_sheet, get_symbol_from_csv, get_gsheet_client,get_Redis_client
+from app.utils import log_trade_to_sheet, get_symbol_from_csv, get_gsheet_client
 from app.auth import get_fyers, get_auth_code_url, get_access_token, refresh_access_token , generate_access_token
 import os
 import logging
@@ -147,14 +147,12 @@ def webhook():
             fyers = get_fyers()
             order_response = place_order(fyers_symbol, qty, action, sl, tp, productType, fyers)
             if order_response.get("s") != "ok":
-                redis = get_Redis_client()
-                redis.set(f"order_error_{fyers_symbol}", order_response.get("message", "Unknown error"))
                 logger.error(f"Fyers order failed: {order_response}")
-                return jsonify({  
+                return jsonify({
                     "code": -1,
                     "message": f"Fyers order failed: {order_response.get('message', 'Unknown error')}",
                     "details": order_response
-                }), 500            
+                }), 500
         except Exception as e:
             logger.exception(f"Exception occured while placing order: {e}")
             return jsonify({

--- a/app/utils.py
+++ b/app/utils.py
@@ -13,7 +13,6 @@ import ssl
 import certifi
 import urllib.request
 import uuid
-import redis
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +28,6 @@ symbol_master_columns = [
 SCOPE = ["https://spreadsheets.google.com/feeds", "https://www.googleapis.com/auth/drive"]
 CREDS_FILE = "/secrets/service_account.json"
 
-# Redis configuration
-REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
-REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 
 _symbol_cache = None
 _gsheet_client = None
@@ -158,10 +154,3 @@ def update_trade_status_in_sheet(_client, trade_id, status, exit_price, reason="
         logger.error(f"Failed to update trade status: {str(e)}")
         return False
     
-def get_Redis_client():
-    try:
-        r =  redis.Redis(host=REDIS_HOST, port=REDIS_PORT)
-        return r
-    except Exception as e:
-        logger.error(f"Failed to connect to Redis: {str(e)}")
-        return None

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -62,18 +62,15 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json()["auth_url"], "https://auth.test")
 
-    @patch("app.routes.get_Redis_client")
     @patch("app.routes.log_trade_to_sheet", return_value=True)
     @patch("app.routes.place_order")
     @patch("app.routes.get_ltp", return_value=200)
     @patch("app.routes.get_fyers")
     @patch("app.routes.get_symbol_from_csv", return_value="NSE:NIFTY245001CE")
     @patch("app.routes.os.getenv", return_value="secret")
-    def test_webhook_success(self, mock_env, mock_resolve, mock_fyers, mock_ltp, mock_order, mock_log_sheet, mock_redis):
+    def test_webhook_success(self, mock_env, mock_resolve, mock_fyers, mock_ltp, mock_order, mock_log_sheet):
         mock_order.return_value = {"s": "ok", "message": "Order placed", "id": "order123"}
         mock_fyers.return_value = MagicMock()
-        mock_redis_instance = MagicMock()
-        mock_redis.return_value = mock_redis_instance
 
         payload = {
             "token": "secret",
@@ -111,10 +108,9 @@ class TestRoutes(unittest.TestCase):
         response = self.client.post("/webhook", json=payload)
         self.assertEqual(response.status_code, 401)
 
-    @patch("app.routes.get_Redis_client")
     @patch("app.routes.get_symbol_from_csv", return_value=None)
     @patch("app.routes.os.getenv", return_value="secret")
-    def test_webhook_symbol_resolution_fail(self, mock_env, mock_resolve, mock_redis):
+    def test_webhook_symbol_resolution_fail(self, mock_env, mock_resolve):
         payload = {
             "token": "secret",
             "symbol": "NIFTY",
@@ -127,17 +123,15 @@ class TestRoutes(unittest.TestCase):
         response = self.client.post("/webhook", json=payload)
         self.assertEqual(response.status_code, 403)
 
-    @patch("app.routes.get_Redis_client")
     @patch("app.routes.log_trade_to_sheet", return_value=True)
     @patch("app.routes.get_fyers")
     @patch("app.routes.get_ltp", return_value=None)
     @patch("app.routes.place_order")
     @patch("app.routes.get_symbol_from_csv", return_value="NSE:NIFTY245001CE")
     @patch("app.routes.os.getenv", return_value="secret")
-    def test_webhook_ltp_none_uses_defaults(self, mock_env, mock_resolve, mock_order, mock_ltp, mock_fyers, mock_log_sheet, mock_redis):
+    def test_webhook_ltp_none_uses_defaults(self, mock_env, mock_resolve, mock_order, mock_ltp, mock_fyers, mock_log_sheet):
         mock_order.return_value = {"s": "ok", "message": "Order placed", "id": "fallback-order"}
         mock_fyers.return_value = MagicMock()
-        mock_redis.return_value = MagicMock()
 
         payload = {
             "token": "secret",
@@ -158,16 +152,14 @@ class TestRoutes(unittest.TestCase):
         self.assertTrue(data["logged_to_sheet"])
         mock_log_sheet.assert_called_once()
 
-    @patch("app.routes.get_Redis_client")
     @patch("app.routes.log_trade_to_sheet", return_value=True)
     @patch("app.routes.place_order")
     @patch("app.routes.get_ltp", return_value=200)
     @patch("app.routes.get_fyers")
     @patch("app.routes.get_symbol_from_csv", return_value="NSE:NIFTY245001CE")
     @patch("app.routes.os.getenv", return_value="secret_token")
-    def test_webhook_success_logs_to_sheet(self, mock_env, mock_resolve, mock_fyers, mock_ltp, mock_order, mock_log_sheet, mock_redis):
+    def test_webhook_success_logs_to_sheet(self, mock_env, mock_resolve, mock_fyers, mock_ltp, mock_order, mock_log_sheet):
         mock_order.return_value = {"s": "ok", "id": "order123", "message": "Order executed"}
-        mock_redis.return_value = MagicMock()
 
         payload = {
             "token": "secret_token",
@@ -187,16 +179,14 @@ class TestRoutes(unittest.TestCase):
         self.assertTrue(data["logged_to_sheet"])
         mock_log_sheet.assert_called_once()
 
-    @patch("app.routes.get_Redis_client")
     @patch("app.routes.log_trade_to_sheet", side_effect=Exception("GSheet failure"))
     @patch("app.routes.place_order")
     @patch("app.routes.get_ltp", return_value=200)
     @patch("app.routes.get_fyers")
     @patch("app.routes.get_symbol_from_csv", return_value="NSE:NIFTY245001CE")
     @patch("app.routes.os.getenv", return_value="secret_token")
-    def test_webhook_log_to_sheet_failure(self, mock_env, mock_resolve, mock_fyers, mock_ltp, mock_order, mock_log_sheet, mock_redis):
+    def test_webhook_log_to_sheet_failure(self, mock_env, mock_resolve, mock_fyers, mock_ltp, mock_order, mock_log_sheet):
         mock_order.return_value = {"s": "ok", "id": "order123", "message": "Order executed"}
-        mock_redis.return_value = MagicMock()
 
         payload = {
             "token": "secret_token",


### PR DESCRIPTION
## Summary
- remove Redis configuration from utils
- streamline order error handling without Redis
- adjust tests to drop redis mocking

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68592ba70bd48328b880e0e13148a267