### PR TITLE
Remove monitor placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ TradingView Strategy --(alert JSON)--> Flask Webhook
   - `routes.py` – Flask blueprint with webhook and utility endpoints.
   - `token_manager.py` – handles token storage and refresh using Google Cloud Storage.
   - `utils.py` – symbol master loader, Google Sheets helpers and Redis client.
-  - `monitor.py` – prototype for a WebSocket based position monitor.
 - `main.py` – entry point that starts the Flask app.
 - `tests/` – unit tests for all modules.
 
@@ -64,13 +63,7 @@ REDIS_PORT=6379
 pip install -r requirements.txt
 ```
 
-4. **Run a local Redis service** (required for the monitor prototype):
-
-```bash
-docker run -p 6379:6379 redis
-```
-
-5. **Run locally**
+4. **Run locally**
 
 ```bash
 export PYTHONPATH=.

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -1,2 +1,0 @@
-# Placeholder for monitor thread implementation.
-

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,2 +1,0 @@
-# Placeholder for monitor service tests.
-


### PR DESCRIPTION
## Summary
- remove unused monitor module and placeholder test
- trim README instructions referencing removed module

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt when Google auth tries network)*

------
https://chatgpt.com/codex/tasks/task_e_68592bb39d008328ac1a615d46d25bb9