### PR TITLE
Document Fyers API helpers

### DIFF
--- a/app/fyers_api.py
+++ b/app/fyers_api.py
@@ -1,3 +1,11 @@
+"""Utility wrappers around the Fyers trading API used by webhook routes.
+
+This module centralizes common interactions with the Fyers API such as
+validating order parameters, retrieving instrument details and placing
+orders. The helpers are intentionally thin so they can be easily mocked in
+tests.
+"""
+
 import logging
 import app.utils as utils
 
@@ -9,6 +17,31 @@ logger = logging.getLogger(__name__)
 valid_product_types = {"INTRADAY", "CNC", "DELIVERY", "BO", "CO"}
 
 def _validate_order_params(symbol, qty, sl, tp, productType):
+    """Sanitise and fill default order parameters.
+
+    Parameters
+    ----------
+    symbol : str
+        Fyers instrument ticker (e.g. ``"NSE:SBIN-EQ"``).
+    qty : int or ``None``
+        Quantity to trade. If ``None`` a sensible default is derived using
+        :func:`_get_default_qty`.
+    sl : float or str or ``None``
+        Desired stop loss in absolute points. Values ``<=0`` are replaced with
+        the default ``10.0``.
+    tp : float or str or ``None``
+        Desired take profit in absolute points. Values ``<=0`` fall back to the
+        default ``20.0``.
+    productType : str
+        Product type supported by Fyers (e.g. ``"CNC"``). Invalid values are
+        logged and replaced with ``"BO"``.
+
+    Returns
+    -------
+    tuple
+        Normalised ``(qty, sl, tp, productType)`` tuple ready for the API call.
+    """
+
     if not qty:
         qty = _get_default_qty(symbol)
     sl = float(sl) if sl and float(sl) > 0 else 10.0
@@ -21,6 +54,20 @@ def _validate_order_params(symbol, qty, sl, tp, productType):
     return qty, sl, tp, productType
 
 def _get_default_qty(symbol):
+    """Return the lot size for a symbol from the loaded symbol master.
+
+    Parameters
+    ----------
+    symbol : str
+        Instrument ticker for which the default lot size is requested.
+
+    Returns
+    -------
+    int
+        Lot size for the symbol if available; otherwise ``1``. Any errors while
+        reading the value are logged and ``1`` is returned.
+    """
+
     if utils._symbol_cache is None:
         utils.load_symbol_master()
 
@@ -36,6 +83,25 @@ def _get_default_qty(symbol):
         return 1
 
 def get_ltp(symbol, fyersModelInstance):
+    """Fetch the latest traded price for a symbol from Fyers.
+
+    Parameters
+    ----------
+    symbol : str
+        Instrument ticker to query.
+    fyersModelInstance : object
+        Instance of :class:`fyers_apiv3.fyersModel.FyersModel` or a compatible
+        mock with ``quotes`` method.
+
+    Returns
+    -------
+    float or None or dict
+        The last traded price as a ``float`` if available. ``None`` is returned
+        when the symbol is not found or no price data is available. If an
+        exception occurs, a dictionary of the form ``{"code": -1, "message" : str(e)}``
+        is returned.
+    """
+
     try:
         response = fyersModelInstance.quotes({"symbols": symbol})
         if response.get("s") == "ok" and response.get("d") and len(response["d"]) > 0:
@@ -49,6 +115,35 @@ def get_ltp(symbol, fyersModelInstance):
         return {"code": -1, "message": str(e)}
 
 def place_order(symbol, qty, action, sl, tp, productType, fyersModelInstance):
+    """Place a market order with Fyers after validating parameters.
+
+    Parameters
+    ----------
+    symbol : str
+        Instrument ticker to trade.
+    qty : int or ``None``
+        Quantity for the order. ``None`` triggers lookup of the default lot
+        size.
+    action : str
+        Either ``"BUY"`` or ``"SELL"`` (case-insensitive).
+    sl : float or ``None``
+        Stop loss value in points. ``None`` or values ``<=0`` default to
+        ``10.0``.
+    tp : float or ``None``
+        Take profit value in points. ``None`` or values ``<=0`` default to
+        ``20.0``.
+    productType : str
+        One of ``valid_product_types``. Invalid values fall back to ``"BO"``.
+    fyersModelInstance : object
+        Fyers client instance or mock providing ``place_order`` method.
+
+    Returns
+    -------
+    dict
+        The raw response from ``fyersModelInstance.place_order``. In case of an
+        exception a dictionary ``{"code": -1, "message": str(e)}`` is returned.
+    """
+
     qty, sl, tp, productType = _validate_order_params(symbol, qty, sl, tp, productType)
     order_data = {
         "symbol": symbol,


### PR DESCRIPTION
## Summary
- add overview of Fyers API helper module
- document `_validate_order_params`, `_get_default_qty`, `get_ltp`, and `place_order`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c56652a208328aa9f9265ed5d6932