### PR TITLE
Add tests for config loader and app factory

### DIFF
--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+from flask import Blueprint, Flask
+
+# Ensure the application package is importable and env vars exist
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("FYERS_APP_ID", "dummy")
+os.environ.setdefault("FYERS_SECRET_ID", "dummy")
+os.environ.setdefault("FYERS_REDIRECT_URI", "http://localhost")
+os.environ.setdefault("WEBHOOK_SECRET_TOKEN", "dummy")
+os.environ.setdefault("GOOGLE_SHEET_ID", "dummy")
+os.environ.setdefault("FYERS_PIN", "0000")
+os.environ.setdefault("FYERS_AUTH_CODE", "dummy")
+
+from app import create_app
+
+
+class TestAppFactory(unittest.TestCase):
+    @patch("app.load_env_variables")
+    def test_create_app_registers_blueprint_and_hooks(self, mock_load_env):
+        test_bp = Blueprint("test", __name__)
+
+        @test_bp.route("/ping")
+        def ping():
+            return "pong"
+
+        with patch("app.webhook_bp", test_bp), \
+             patch("app.logger") as mock_logger:
+            app = create_app()
+            self.assertIsInstance(app, Flask)
+            self.assertIn("test", app.blueprints)
+
+            client = app.test_client()
+            response = client.get("/ping")
+            self.assertEqual(response.status_code, 200)
+
+            # Verify after_request logged with request_id
+            has_request_id = any(
+                kwargs.get("extra") and "request_id" in kwargs["extra"]
+                for _, kwargs in mock_logger.info.call_args_list
+            )
+            self.assertTrue(has_request_id)
+
+        mock_load_env.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Ensure the application package is importable
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.config import load_env_variables
+
+
+class TestConfigModule(unittest.TestCase):
+    @patch("app.config.load_dotenv")
+    def test_load_env_variables_success(self, mock_load):
+        env = {
+            "FYERS_APP_ID": "id",
+            "FYERS_SECRET_ID": "secret",
+            "FYERS_REDIRECT_URI": "http://localhost",
+            "WEBHOOK_SECRET_TOKEN": "token",
+            "GOOGLE_SHEET_ID": "sheet",
+            "FYERS_PIN": "1234",
+            "FYERS_AUTH_CODE": "code",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            # Should not raise when all variables are present
+            load_env_variables()
+
+    @patch("app.config.load_dotenv")
+    def test_load_env_variables_missing_var(self, mock_load):
+        env = {
+            "FYERS_APP_ID": "id",
+            "FYERS_SECRET_ID": "secret",
+            "FYERS_REDIRECT_URI": "http://localhost",
+            "WEBHOOK_SECRET_TOKEN": "token",
+            "GOOGLE_SHEET_ID": "sheet",
+            "FYERS_PIN": "1234",
+            # FYERS_AUTH_CODE intentionally omitted
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(EnvironmentError) as cm:
+                load_env_variables()
+            self.assertIn("FYERS_AUTH_CODE", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cover `load_env_variables` with success & failure cases
- add app factory test ensuring blueprint registration and request hooks

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5a51a688832895ede26fd8926301