### PR TITLE
Add module docstring for token manager

### DIFF
--- a/app/token_manager.py
+++ b/app/token_manager.py
@@ -1,3 +1,11 @@
+"""Handle Fyers API authentication tokens.
+
+This module manages access and refresh tokens for the Fyers trading API. It
+supports persisting tokens to Google Cloud Storage or a local ``tokens.json``
+file and exposes a thread-safe :class:`TokenManager` singleton through
+``get_token_manager``.
+"""
+
 import os
 import json
 import hashlib


### PR DESCRIPTION
## Summary
- document the purpose of `app/token_manager.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c5a59ea088328a9e674166b6d1c00