### PR TITLE
Improve branch coverage tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+branch = True
+source = app

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -82,5 +82,43 @@ class TestAuth(unittest.TestCase):
         with self.assertRaises(Exception):
             auth.get_fyers()
 
+    @patch("app.auth.get_token_manager")
+    def test_get_auth_code_url_exception(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.get_auth_code_url.side_effect = Exception("boom")
+        mock_get_mgr.return_value = manager
+
+        with self.assertRaises(Exception):
+            auth.get_auth_code_url()
+
+    @patch("app.auth.get_token_manager")
+    def test_refresh_access_token_general_exception(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.refresh_token.side_effect = Exception("oops")
+        mock_get_mgr.return_value = manager
+
+        with self.assertRaises(Exception):
+            auth.refresh_access_token()
+
+    @patch("app.auth.get_token_manager")
+    def test_generate_access_token_none(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.generate_token.return_value = None
+        mock_get_mgr.return_value = manager
+
+        token = auth.generate_access_token()
+        self.assertIsNone(token)
+        manager.generate_token.assert_called_once()
+
+    @patch("app.auth.get_token_manager")
+    def test_generate_access_token_exception(self, mock_get_mgr):
+        manager = MagicMock()
+        manager.generate_token.side_effect = Exception("err")
+        mock_get_mgr.return_value = manager
+
+        token = auth.generate_access_token()
+        self.assertIsNone(token)
+        manager.generate_token.assert_called_once()
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -69,3 +69,12 @@ def test_configure_logging_with_log_file(mock_basic, mock_get_logger):
     assert mock_basic.call_args.kwargs["level"] == logging.INFO
     root_logger.addFilter.assert_called_once()
     handler.addFilter.assert_called_once()
+
+
+def test_request_id_filter_adds_request_id():
+    filt = RequestIdFilter()
+    record = logging.LogRecord("name", logging.INFO, __file__, 0, "msg", None, None)
+    with patch("app.logging_config.get_request_id", return_value="abc"):
+        result = filt.filter(record)
+    assert result is True
+    assert getattr(record, "request_id") == "abc"


### PR DESCRIPTION
## Summary
- add coverage configuration to focus on `app` package
- extend tests for auth, routes, logging, and token manager to hit error branches
- add additional webhook and token manager tests

## Testing
- `pytest -q`
- `coverage run -m pytest -q && coverage xml -o coverage.xml && grep -n "coverage" coverage.xml | head`


------
https://chatgpt.com/codex/tasks/task_e_685c55a6a7a48328985d9a7f03c2e765