### PR TITLE
Update container to use gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl --fail http://localhost:8080/readyz || exit 1
 
-CMD ["python", "main.py"]
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "main:app"]
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ You can deploy the container to Google Cloud Run or any other container platform
 ```bash
 gcloud builds submit --config cloudbuild.yaml
 ```
+The container runs using **Gunicorn** with the command:
+
+```bash
+gunicorn -b 0.0.0.0:8080 main:app
+```
+
 
 ## Sample Webhook Payload
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ gcloud
 yapf
 pytz
 google-cloud-storage
+gunicorn


### PR DESCRIPTION
## Summary
- use gunicorn as the app server
- document the gunicorn command in the deployment instructions
- add gunicorn dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625528012483288be7cb972d7ae262