### PR TITLE
Add thread locks to utils

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -565,3 +565,11 @@ def test_update_trade_status_in_sheet_custom_sheet(monkeypatch):
     mock_sheet_instance.worksheet.assert_called_once_with("TestSheet")
     assert mock_sheet.update_cell.call_count >= 4  # At least 4 calls should be made
     assert result is True
+
+
+def test_module_locks_exist():
+    assert hasattr(app.utils, "_gsheet_lock")
+    assert hasattr(app.utils._gsheet_lock, "acquire")
+    assert hasattr(app.utils, "_symbol_lock")
+    assert hasattr(app.utils._symbol_lock, "acquire")
+


### PR DESCRIPTION
## Summary
- ensure utils module initialization is thread-safe
- add tests for new lock objects

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625f5b2d5c83289795958bba60e63d