### PR TITLE
Add pre-check for open short position

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ TradingView Strategy --(alert JSON)--> Flask Webhook
 1. A Pine Script strategy sends an alert to `/webhook` with a secret token.
 2. The service validates the payload and looks up the correct Fyers symbol from the NSE_FO master CSV.
 3. The current LTP is fetched from Fyers to set stop loss and target if not provided.
-4. The order is placed using the Fyers REST API and the details are logged to Google Sheets.
+4. Before placing a ``BUY`` order the service checks your Fyers positions to ensure a short position already exists. If none is found the alert is rejected. Otherwise the order is executed via the Fyers REST API and the details are logged to Google Sheets.
 5. Utility endpoints allow generating the auth URL, refreshing tokens and health checks.
 6. A monitoring service via WebSocket can be added later to track open positions.
 

--- a/tests/test_fyers_api.py
+++ b/tests/test_fyers_api.py
@@ -18,7 +18,8 @@ from app.fyers_api import (
     _validate_order_params,
     _get_default_qty,
     get_ltp,
-    place_order
+    place_order,
+    has_short_position
 )
 
 class TestFyersAPI(unittest.TestCase):
@@ -328,6 +329,30 @@ class TestFyersAPI(unittest.TestCase):
         # Verify function handles exception correctly
         self.assertEqual(result, {"code": -1, "message": "Order API Error"})
         mock_logger.exception.assert_called_once()
+
+    def test_has_short_position_true(self):
+        """has_short_position returns True when netQty is negative."""
+        self.mock_fyers.positions.return_value = {
+            "s": "ok",
+            "netPositions": [
+                {"symbol": "NSE:SBIN-EQ", "netQty": -10, "side": -1}
+            ]
+        }
+
+        result = has_short_position("NSE:SBIN-EQ", self.mock_fyers)
+        self.assertTrue(result)
+
+    def test_has_short_position_false(self):
+        """has_short_position returns False when no short position present."""
+        self.mock_fyers.positions.return_value = {
+            "s": "ok",
+            "netPositions": [
+                {"symbol": "NSE:SBIN-EQ", "netQty": 10, "side": 1}
+            ]
+        }
+
+        result = has_short_position("NSE:SBIN-EQ", self.mock_fyers)
+        self.assertFalse(result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add helper to detect short positions
- check for short position in webhook route before buying
- test the new helper and route logic
- document short position pre-check workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d255673c83289d31954f685b8498