### PR TITLE
Fix expiry in payload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,15 @@ gunicorn -b 0.0.0.0:8080 main:app
 
 ## Sample Webhook Payload
 
+The `expiry` field should be either `"WEEKLY"` or `"MONTHLY"`.
+
 ```json
 {
   "token": "<WEBHOOK_SECRET>",
   "symbol": "NSE:BANKNIFTY",
   "strikeprice": 48400,
   "optionType": "PE",
-  "expiry": "2025-05-22",
+  "expiry": "WEEKLY",
   "action": "SELL",
   "qty": 25,
   "sl": 50,


### PR DESCRIPTION
## Summary
- update sample webhook payload to use WEEKLY expiry
- clarify that expiry must be WEEKLY or MONTHLY

## Testing
- `pip install -r requirements.txt`
- `pip install 'flask[async]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f2a5b43c8328ba20a38b7ad31676