### PR TITLE
Update README sample payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ gunicorn -b 0.0.0.0:8080 main:app
 ## Sample Webhook Payload
 
 The `expiry` field should be either `"WEEKLY"` or `"MONTHLY"`.
+Stop loss (`sl`) and take profit (`tp`) are optional—the service
+calculates them from the current LTP when they are omitted or invalid.
 
 ```json
 {
@@ -119,8 +121,6 @@ The `expiry` field should be either `"WEEKLY"` or `"MONTHLY"`.
   "expiry": "WEEKLY",
   "action": "SELL",
   "qty": 25,
-  "sl": 50,
-  "tp": 100,
   "productType": "BO"
 }
 ```


### PR DESCRIPTION
## Summary
- trim stop loss and take profit from the example webhook payload
- explain that the service derives SL/TP from current LTP

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6863efd740c4832892c72c267fb8d285