### PR TITLE
Fix generate_access_token error handling

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -116,4 +116,5 @@ def generate_access_token():
             logger.error("[AUTH] Token generation returned None")
     except Exception as e:
         logger.exception("[AUTH] Error generating token: %s", e)
+        raise
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -115,8 +115,8 @@ class TestAuth(unittest.TestCase):
         manager.generate_token.side_effect = Exception("err")
         mock_get_mgr.return_value = manager
 
-        token = auth.generate_access_token()
-        self.assertIsNone(token)
+        with self.assertRaises(Exception):
+            auth.generate_access_token()
         manager.generate_token.assert_called_once()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- propagate exceptions from `generate_access_token`
- update unit test to expect the raised error

## Testing
- `pip install -q 'flask[async]'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643a08b840832891f95eddaedb7952