### PR TITLE
Fix async routes by adding asgiref

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask
+asgiref>=3.7
 requests
 python-dotenv
 fyers-apiv3


### PR DESCRIPTION
## Summary
- add `asgiref` runtime dependency for Flask async support

## Testing
- `pytest -q`
- `docker build -t testimage .` *(fails: `docker` not found)*
- `uvicorn main:asgi_app --port 8080 --host 0.0.0.0` *(manual check of `/readyz` returns 500 from Fyers API without async errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864a217b3d883289e9d60b898ac1b59