### PR TITLE
Add dockerignore to slim Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Exclude development and test files
+.git
+.gitignore
+*.md
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*.swp
+.DS_Store
+.vscode/
+.idea/
+.pytest_cache/
+.coverage
+.coveragerc
+tests/
+docker-compose.yml
+cloudbuild.yaml


### PR DESCRIPTION
## Summary
- add `.dockerignore` to omit test and tooling files from the Docker build context

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: RuntimeError: Install Flask with the 'async' extra in order to use async views)*
- `docker build -t trading-bot-webhook .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864a2334ec083289d89078589c07674