### PR TITLE
Add token expiry handling and automatic refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ calculates them from the current LTP when they are omitted or invalid.
 - `POST /refresh-token` – refresh the Fyers access token.
 - `GET /readyz` – basic health check.
 
+### Automated Token Refresh
+
+Schedule a Cloud Scheduler job to call `/refresh-token` daily:
+
+```
+gcloud scheduler jobs create http refresh-fyers-token \
+  --schedule="0 0 * * *" \
+  --uri="https://<your-service-url>/refresh-token" \
+  --http-method=POST
+```
+
+This keeps the access token alive without manual intervention.
+
 ## Testing
 
 Install dependencies with `pip install -r requirements.txt` before running the tests. Using a virtual environment is recommended.

--- a/app/fyers_api.py
+++ b/app/fyers_api.py
@@ -9,6 +9,7 @@ tests.
 import logging
 import inspect
 import app.utils as utils
+from app.token_manager import get_token_manager
 
 if utils._symbol_cache is None:
     utils.load_symbol_master()
@@ -112,6 +113,12 @@ async def get_ltp(symbol, fyersModelInstance):
         response = fyersModelInstance.quotes({"symbols": symbol})
         if inspect.iscoroutine(response):
             response = await response
+        if response.get("code") == 401:
+            get_token_manager().refresh_token()
+            fyersModelInstance = get_token_manager().get_fyers_client()
+            response = fyersModelInstance.quotes({"symbols": symbol})
+            if inspect.iscoroutine(response):
+                response = await response
         if response.get("s") == "ok" and response.get("d") and len(
                 response["d"]) > 0:
             return response.get("d", [{}])[0].get("v", {}).get("lp")
@@ -150,6 +157,12 @@ async def has_short_position(symbol, fyersModelInstance):
         response = fyersModelInstance.positions()
         if inspect.iscoroutine(response):
             response = await response
+        if response.get("code") == 401:
+            get_token_manager().refresh_token()
+            fyersModelInstance = get_token_manager().get_fyers_client()
+            response = fyersModelInstance.positions()
+            if inspect.iscoroutine(response):
+                response = await response
         logger.debug(f"Positions response: {response}")
         if response.get("s") != "ok":
             logger.warning(f"Positions API returned error: {response}")
@@ -224,6 +237,12 @@ async def place_order(symbol, qty, action, sl, tp, productType,
         response = fyersModelInstance.place_order(order_data)
         if inspect.iscoroutine(response):
             response = await response
+        if response.get("code") == 401:
+            get_token_manager().refresh_token()
+            fyersModelInstance = get_token_manager().get_fyers_client()
+            response = fyersModelInstance.place_order(order_data)
+            if inspect.iscoroutine(response):
+                response = await response
         logger.debug(f"Response from Fyers order API: {response}")
         return response
     except Exception as e:


### PR DESCRIPTION
## Summary
- track access token issuance/expiry in `TokenManager`
- auto refresh tokens when expired or unauthorized
- document Cloud Scheduler job for daily token refresh
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b8e45b8608328953d6e8dd160fd8b