### PR TITLE
Add CI tests and reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
 FROM python:3.12-slim
 
-# Install system dependencies, including CA certificates
-RUN apt-get update && apt-get install -y \
-build-essential \
-libffi-dev \
-libssl-dev \
-ca-certificates \
-&& rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+# Install build dependencies and Python packages
+COPY requirements.txt ./
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        ca-certificates && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apt-get purge -y --auto-remove build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-
-WORKDIR /app
-
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ docker compose up
 
 ## Deployment
 
-You can deploy the container to Google Cloud Run or any other container platform such as GKE. A `cloudbuild.yaml` file is provided to automate building and deploying the image. Run the following command:
+You can deploy the container to Google Cloud Run or any other container platform such as GKE. A `cloudbuild.yaml` file is provided to automate building, testing and deploying the image. Cloud Build installs the dependencies, runs the test suite and only then builds the container. Trigger a build with:
 
 ```bash
 gcloud builds submit --config cloudbuild.yaml

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,14 @@
 steps:
+  - name: 'python:3.12-slim'
+    id: 'Run tests'
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        apt-get update && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev ca-certificates
+        pip install --no-cache-dir -r requirements.txt
+        pytest -q
   - name: 'gcr.io/cloud-builders/docker'
     args: [
       'build',
@@ -20,7 +30,8 @@ steps:
       '--region=asia-south1',
       '--platform=managed',
       '--allow-unauthenticated',
-      '--service-account=trading-bot-webhook@trading-bot-webhook.iam.gserviceaccount.com'
+      '--service-account=trading-bot-webhook@trading-bot-webhook.iam.gserviceaccount.com',
+      '--quiet'
     ]
 
 options:


### PR DESCRIPTION
## Summary
- slim down Dockerfile by purging build deps after install
- run unit tests in Cloud Build before building image
- make Cloud Build deployment non-interactive
- clarify deployment automation in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68734f5fddf0832880828ede9c781a4b