### PR TITLE
Specify minimum Flask version for async routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To encrypt token data, enable the **Cloud KMS** API and set the `KMS_KEY_NAME` e
 ```bash
 pip install -r requirements.txt
 ```
+This project requires **Flask 2.0 or higher** in order to use asynchronous routes.
 
 4. **Run locally**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask>=2.0
 asgiref>=3.7
 requests
 python-dotenv


### PR DESCRIPTION
## Summary
- set a minimum Flask version in `requirements.txt`
- document Flask 2.0+ requirement in the setup instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c1bfbd08832885bd25a644e87451