### PR TITLE
Restore credentials file fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,17 @@ pip install -r requirements.txt
 ```
 This project requires **Flask 2.0 or higher** in order to use asynchronous routes.
 
-4. **Run locally**
+4. **Generate Fyers tokens**
+
+   1. Call `GET /auth-url` to open the Fyers login page.
+   2. Complete the login, copy the authorization code and set `FYERS_AUTH_CODE` in `.env`.
+   3. Run `POST /generate-token` once. This creates `tokens.json` locally (and in GCS if configured).
+      The file is stored in **base64** format; always use the provided endpoints to
+      update it rather than editing manually.
+
+   Until this step is done the `/readyz` health check will fail with a "Bad request" error from Fyers.
+
+5. **Run locally**
 
 ```bash
 export PYTHONPATH=.

--- a/app/token_manager.py
+++ b/app/token_manager.py
@@ -22,6 +22,10 @@ from app.notifications import send_notification
 logger = logging.getLogger(__name__)
 
 TOKENS_FILE = "tokens.json"
+# Default location for the Google service account key. This allows token
+# storage in Cloud Storage without requiring the caller to set
+# ``GOOGLE_APPLICATION_CREDENTIALS`` explicitly.
+CREDS_FILE = "/secrets/service_account.json"
 
 # Thread-safe singleton
 _token_manager_instance = None
@@ -91,6 +95,15 @@ class TokenManager:
         self._lock = threading.RLock()  # Reentrant lock for thread safety
         self.token_validity_seconds = self.TOKEN_VALIDITY_SECONDS
 
+    def _get_storage_client(self):
+        """Return a Google Cloud Storage client using the service account key
+        if available."""
+
+        cred_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", CREDS_FILE)
+        if os.path.exists(cred_path):
+            return storage.Client.from_service_account_json(cred_path)
+        return storage.Client()
+
     def _encrypt(self, data: bytes) -> str:
         """Encode bytes to a base64 string."""
         try:
@@ -110,7 +123,7 @@ class TokenManager:
     def _load_tokens(self):
         """Retrieve tokens from GCS first, then fall back to the local file."""
         try:
-            storage_client = storage.Client()
+            storage_client = self._get_storage_client()
             bucket = storage_client.bucket(os.getenv("GCS_BUCKET_NAME"))
             blob = bucket.blob(
                 os.getenv("GCS_TOKENS_FILE", "tokens/tokens.json"))
@@ -121,8 +134,12 @@ class TokenManager:
                 logger.info("Loaded tokens from %s into %s", gcs_path,
                             self.tokens_file)
                 with open(self.tokens_file, "r") as f:
-                    encrypted = f.read()
-                plaintext = self._decrypt(encrypted)
+                    raw = f.read()
+                try:
+                    plaintext = self._decrypt(raw)
+                except TokenManagerException:
+                    logger.warning("Tokens file not encoded; loading plaintext")
+                    plaintext = raw.encode()
                 return json.loads(plaintext.decode())
             else:
                 gcs_path = f"gs://{bucket.name}/{blob.name}"
@@ -135,10 +152,15 @@ class TokenManager:
         try:
             if os.path.exists(self.tokens_file):
                 with open(self.tokens_file, "r") as f:
-                    encrypted = f.read()
+                    raw = f.read()
                 logger.info("Loaded tokens from local file %s",
                             self.tokens_file)
-                plaintext = self._decrypt(encrypted)
+                try:
+                    plaintext = self._decrypt(raw)
+                except TokenManagerException:
+                    logger.warning(
+                        "Tokens file not encoded; loading plaintext")
+                    plaintext = raw.encode()
                 return json.loads(plaintext.decode())
             else:
                 logger.warning(
@@ -157,7 +179,7 @@ class TokenManager:
                 with open(self.tokens_file, "w") as f:
                     f.write(encrypted)
 
-                storage_client = storage.Client()
+                storage_client = self._get_storage_client()
                 bucket = storage_client.bucket(os.getenv("GCS_BUCKET_NAME"))
                 blob = bucket.blob(
                     os.getenv("GCS_TOKENS_FILE", "tokens/tokens.json"))

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -69,7 +69,11 @@ class TestTokenManager(unittest.TestCase):
         self.mock_init_session_model = self.init_session_patcher.start()
 
         # Patch heavy external dependencies
-        self.gcs_client_patcher = patch('google.cloud.storage.Client')
+        self.gcs_client_mock = MagicMock()
+        self.gcs_client_patcher = patch(
+            'app.token_manager.TokenManager._get_storage_client',
+            return_value=self.gcs_client_mock
+        )
         self.mock_gcs_client = self.gcs_client_patcher.start()
 
         self.fyers_model_patcher = patch(
@@ -105,12 +109,12 @@ class TestTokenManager(unittest.TestCase):
         """Test loading tokens when file doesn't exist."""
         self.load_tokens_patcher.stop()
         # Ensure the mocked GCS client returns a blob that does not exist
-        self.mock_gcs_client.return_value.bucket.return_value.blob.return_value.exists.return_value = False
+        self.gcs_client_mock.bucket.return_value.blob.return_value.exists.return_value = False
 
         manager = TokenManager()
         self.assertEqual(manager._tokens, {})
 
-    @patch("google.cloud.storage.Client")
+    @patch("app.token_manager.TokenManager._get_storage_client")
     @patch("builtins.open",
            new_callable=mock_open,
            read_data=
@@ -161,7 +165,7 @@ class TestTokenManager(unittest.TestCase):
                                                     mock_exists):
         """Load tokens from local file if GCS blob is missing."""
         self.load_tokens_patcher.stop()
-        self.mock_gcs_client.return_value.bucket.return_value.blob.return_value.exists.return_value = False
+        self.gcs_client_mock.bucket.return_value.blob.return_value.exists.return_value = False
 
         manager = TokenManager()
 
@@ -169,7 +173,8 @@ class TestTokenManager(unittest.TestCase):
         self.assertEqual(manager._tokens["refresh_token"], "local_refresh")
         mock_file.assert_called_with("tokens.json", "r")
 
-    @patch("google.cloud.storage.Client", side_effect=Exception("GCS error"))
+    @patch("app.token_manager.TokenManager._get_storage_client",
+           side_effect=Exception("GCS error"))
     @patch("os.path.exists", return_value=True)
     @patch("builtins.open",
            new_callable=mock_open,
@@ -184,6 +189,28 @@ class TestTokenManager(unittest.TestCase):
 
         self.assertEqual(manager._tokens["access_token"], "local_token")
         self.assertEqual(manager._tokens["refresh_token"], "local_refresh")
+        mock_file.assert_called_with("tokens.json", "r")
+
+    @patch("app.token_manager.TokenManager._get_storage_client")
+    @patch("builtins.open", new_callable=mock_open, read_data='{"access_token": "plain"}')
+    def test_load_tokens_plaintext(self, mock_file, mock_gcs_client):
+        """Handle tokens file that is not base64 encoded."""
+        self.load_tokens_patcher.stop()
+
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+        mock_blob.download_to_filename.return_value = None
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_client_instance = MagicMock()
+        mock_client_instance.bucket.return_value = mock_bucket
+        mock_gcs_client.return_value = mock_client_instance
+
+        with patch('app.token_manager.TokenManager._decrypt', side_effect=TokenManagerException('bad')):
+            manager = TokenManager()
+
+        self.assertEqual(manager._tokens["access_token"], "plain")
         mock_file.assert_called_with("tokens.json", "r")
 
     @patch("builtins.open", new_callable=mock_open)


### PR DESCRIPTION
## Summary
- add CREDS_FILE constant for default service account key
- load credentials from the key when accessing GCS
- update tests for new helper
- clarify that tokens.json is base64 encoded
- fallback to plaintext tokens file if decryption fails

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d2e30b54832882d77774feabed7c