### PR TITLE
Improve health check token message

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This project requires **Flask 2.0 or higher** in order to use asynchronous route
    2. Complete the login, copy the authorization code and set `FYERS_AUTH_CODE` in `.env`.
    3. Run `POST /generate-token` once. This creates `tokens.json` locally (and in GCS if configured).
 
-   Until this step is done the `/readyz` health check will fail with a "Bad request" error from Fyers.
+   Until this step is done the `/readyz` health check will fail with an "Access token unavailable or invalid" message.
 
 5. **Run locally**
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,6 +44,10 @@ async def health_check():
             profile_response = await profile_response
 
         if profile_response.get("s") != "ok":
+            message = profile_response.get("message", "")
+            code = profile_response.get("code")
+            if message == "Bad request" or code == -99:
+                raise Exception("Access token unavailable or invalid")
             raise Exception(f"Fyers API ping failed: {profile_response}")
 
         return jsonify({

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -287,6 +287,22 @@ class TestRoutes(unittest.TestCase):
 
     @patch("app.routes.get_fyers")
     @patch("app.routes.get_access_token")
+    def test_health_check_bad_request(self, mock_get_token, mock_get_fyers):
+        mock_get_token.return_value = "tok"
+        mock_fyers = MagicMock()
+        mock_fyers.get_profile = AsyncMock(
+            return_value={"s": "error", "code": -99, "message": "Bad request"}
+        )
+        mock_get_fyers.return_value = mock_fyers
+
+        response = self.client.get("/readyz")
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.get_json()["message"], "Access token unavailable or invalid"
+        )
+
+    @patch("app.routes.get_fyers")
+    @patch("app.routes.get_access_token")
     def test_health_check_exception(self, mock_get_token, mock_get_fyers):
         mock_get_token.return_value = "valid"
         mock_get_fyers.side_effect = Exception("boom")


### PR DESCRIPTION
## Summary
- detect Fyers 'Bad request' response during health check
- surface a clearer 'Access token unavailable or invalid' error
- document the new message in README
- test coverage for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68751b3ff1e08328a9ba8399ba4a46d7