### PR TITLE
Add Angel token manager module and tests

### DIFF
--- a/app/angel_token_manager.py
+++ b/app/angel_token_manager.py
@@ -1,0 +1,150 @@
+"""Utilities for managing Angel One SmartAPI tokens."""
+
+import os
+import json
+import logging
+import base64
+from google.cloud import storage
+import requests
+
+logger = logging.getLogger(__name__)
+
+TOKENS_FILE = "angel_tokens.json"
+CREDS_FILE = "/secrets/service_account.json"
+
+
+def _get_storage_client():
+    """Return a Google Cloud Storage client using a service account if available."""
+    cred_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", CREDS_FILE)
+    if os.path.exists(cred_path):
+        return storage.Client.from_service_account_json(cred_path)
+    return storage.Client()
+
+
+def _encrypt(data: bytes) -> str:
+    try:
+        return base64.b64encode(data).decode()
+    except Exception as exc:
+        logger.exception("Encryption failed: %s", exc)
+        raise
+
+
+def _decrypt(data: str) -> bytes:
+    try:
+        return base64.b64decode(data)
+    except Exception as exc:
+        logger.exception("Decryption failed: %s", exc)
+        raise
+
+
+def load_tokens(tokens_file: str = TOKENS_FILE):
+    """Load tokens from GCS if present, otherwise from local file."""
+    try:
+        storage_client = _get_storage_client()
+        bucket = storage_client.bucket(os.getenv("GCS_BUCKET_NAME"))
+        blob = bucket.blob(os.getenv("GCS_TOKENS_FILE", f"tokens/{tokens_file}"))
+        if blob.exists():
+            blob.download_to_filename(tokens_file)
+            with open(tokens_file, "r") as fh:
+                raw = fh.read()
+            try:
+                plaintext = _decrypt(raw)
+            except Exception:
+                logger.warning("Tokens file not encoded; loading plaintext")
+                plaintext = raw.encode()
+            return json.loads(plaintext.decode())
+    except Exception as exc:
+        logger.exception("GCS load failed: %s", exc)
+    try:
+        if os.path.exists(tokens_file):
+            with open(tokens_file, "r") as fh:
+                raw = fh.read()
+            try:
+                plaintext = _decrypt(raw)
+            except Exception:
+                logger.warning("Tokens file not encoded; loading plaintext")
+                plaintext = raw.encode()
+            return json.loads(plaintext.decode())
+    except Exception as exc:
+        logger.exception("Local load failed: %s", exc)
+    return {}
+
+
+def save_tokens(tokens: dict, tokens_file: str = TOKENS_FILE):
+    """Save tokens locally and to GCS."""
+    plaintext = json.dumps(tokens).encode()
+    encrypted = _encrypt(plaintext)
+    try:
+        with open(tokens_file, "w") as fh:
+            fh.write(encrypted)
+        storage_client = _get_storage_client()
+        bucket = storage_client.bucket(os.getenv("GCS_BUCKET_NAME"))
+        blob = bucket.blob(os.getenv("GCS_TOKENS_FILE", f"tokens/{tokens_file}"))
+        blob.upload_from_filename(tokens_file)
+    except Exception as exc:
+        logger.exception("GCS save failed: %s", exc)
+
+
+def get_login_url() -> str:
+    """Return the login URL for manual SmartAPI authentication."""
+    api_key = os.getenv("ANGEL_API_KEY")
+    redirect = os.getenv("ANGEL_REDIRECT_URI")
+    state = os.getenv("ANGEL_STATE", "state")
+    return (
+        "https://smartapi.angelbroking.com/publisher-login?"
+        f"api_key={api_key}&redirect_uri={redirect}&response_type=code&state={state}"
+    )
+
+
+def generate_tokens(auth_code: str):
+    """Exchange an auth code for access and refresh tokens."""
+    api_key = os.getenv("ANGEL_API_KEY")
+    client_code = os.getenv("ANGEL_CLIENT_CODE")
+    password = os.getenv("ANGEL_PASSWORD")
+    url = (
+        "https://apiconnect.angelbroking.com/rest/auth/angelbroking/jwt/v1/"
+        "generateTokens"
+    )
+    payload = {
+        "api_key": api_key,
+        "clientcode": client_code,
+        "password": password,
+        "code": auth_code,
+    }
+    response = requests.post(url, json=payload).json()
+    if response.get("status") in (True, "success"):
+        data = response.get("data", response)
+        tokens = {
+            "access_token": data.get("access_token"),
+            "refresh_token": data.get("refresh_token"),
+        }
+        save_tokens(tokens)
+        return tokens
+    raise Exception(f"Token generation failed: {response}")
+
+
+def refresh_tokens():
+    """Refresh and persist the access token using the stored refresh token."""
+    tokens = load_tokens()
+    refresh_token = tokens.get("refresh_token")
+    if not refresh_token:
+        raise Exception("Missing refresh token")
+    api_key = os.getenv("ANGEL_API_KEY")
+    url = (
+        "https://apiconnect.angelbroking.com/rest/auth/angelbroking/jwt/v1/"
+        "generateTokens"
+    )
+    payload = {"api_key": api_key, "refresh_token": refresh_token}
+    response = requests.post(url, json=payload).json()
+    if response.get("status") in (True, "success"):
+        data = response.get("data", response)
+        tokens.update(
+            {
+                "access_token": data.get("access_token"),
+                "refresh_token": data.get("refresh_token", refresh_token),
+            }
+        )
+        save_tokens(tokens)
+        return tokens
+    raise Exception(f"Token refresh failed: {response}")
+

--- a/tests/test_angel_token_manager.py
+++ b/tests/test_angel_token_manager.py
@@ -1,0 +1,97 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app import angel_token_manager as atm
+
+
+class TestAngelTokenManager(unittest.TestCase):
+    def setUp(self):
+        self.env = patch.dict(os.environ, {
+            "ANGEL_API_KEY": "key",
+            "ANGEL_REDIRECT_URI": "http://localhost",
+            "ANGEL_CLIENT_CODE": "client",
+            "ANGEL_PASSWORD": "pass",
+            "GCS_BUCKET_NAME": "bucket",
+            "GCS_TOKENS_FILE": "tokens/angel.json",
+        })
+        self.env.start()
+
+        self.client_mock = MagicMock()
+        patcher = patch('app.angel_token_manager._get_storage_client', return_value=self.client_mock)
+        self.mock_storage = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        enc = patch('app.angel_token_manager._encrypt', side_effect=lambda b: b.decode())
+        dec = patch('app.angel_token_manager._decrypt', side_effect=lambda s: s.encode())
+        self.mock_enc = enc.start()
+        self.mock_dec = dec.start()
+        self.addCleanup(enc.stop)
+        self.addCleanup(dec.stop)
+
+    def tearDown(self):
+        self.env.stop()
+
+    def test_get_login_url(self):
+        url = atm.get_login_url()
+        self.assertIn("key", url)
+        self.assertIn("http://localhost", url)
+
+    @patch('app.angel_token_manager.save_tokens')
+    @patch('requests.post')
+    def test_generate_tokens_success(self, mock_post, mock_save):
+        mock_post.return_value.json.return_value = {
+            "status": "success",
+            "data": {"access_token": "a", "refresh_token": "r"}
+        }
+        tokens = atm.generate_tokens('code')
+        self.assertEqual(tokens['access_token'], 'a')
+        mock_save.assert_called_once()
+
+    @patch('requests.post')
+    def test_generate_tokens_failure(self, mock_post):
+        mock_post.return_value.json.return_value = {"status": "error"}
+        with self.assertRaises(Exception):
+            atm.generate_tokens('code')
+
+    @patch('app.angel_token_manager.save_tokens')
+    @patch('requests.post')
+    @patch('app.angel_token_manager.load_tokens', return_value={'refresh_token': 'r'})
+    def test_refresh_tokens_success(self, mock_load, mock_post, mock_save):
+        mock_post.return_value.json.return_value = {
+            "status": "success",
+            "data": {"access_token": "new", "refresh_token": "nr"}
+        }
+        tokens = atm.refresh_tokens()
+        self.assertEqual(tokens['access_token'], 'new')
+        mock_save.assert_called_once()
+
+    @patch('app.angel_token_manager.load_tokens', return_value={})
+    def test_refresh_tokens_missing(self, mock_load):
+        with self.assertRaises(Exception):
+            atm.refresh_tokens()
+
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open, read_data='{"a":"b"}')
+    def test_load_tokens_file_not_exists(self, mopen, mexists):
+        bucket = self.client_mock.bucket.return_value
+        blob = bucket.blob.return_value
+        blob.exists.return_value = False
+        tokens = atm.load_tokens('f.json')
+        self.assertEqual(tokens, {'a': 'b'})
+        mopen.assert_called_with('f.json', 'r')
+
+    @patch('builtins.open', new_callable=mock_open)
+    def test_save_tokens_success(self, mopen):
+        bucket = self.client_mock.bucket.return_value
+        blob = bucket.blob.return_value
+        atm.save_tokens({'a': 'b'}, 'file.json')
+        mopen.assert_called_with('file.json', 'w')
+        blob.upload_from_filename.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement SmartAPI token utilities in `angel_token_manager`
- add unit tests for new angel token manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a216f90f48328b662f476f5aad40b